### PR TITLE
[SOK-46] настроил очистку пуль при запуске игры, а также выяснил причину …

### DIFF
--- a/packages/client/src/components/Game/Game.tsx
+++ b/packages/client/src/components/Game/Game.tsx
@@ -117,6 +117,7 @@ export const Game = (props: GamePropsType) => {
     playerRef.current = PLAYER_DEFAULT_PARAMS
     enemiesRef.current = initializeRandomEnemies(5)
     obstaclesRef.current = initializeRandomObstacle(20)
+    bulletsRef.current = []
     isStartedLoopRef.current = false
   }, [lives])
 
@@ -129,6 +130,7 @@ export const Game = (props: GamePropsType) => {
     playerRef.current = PLAYER_DEFAULT_PARAMS
     enemiesRef.current = initializeCampanyEnemies()
     obstaclesRef.current = initializeCompanyMapObstacle()
+    bulletsRef.current = []
     isStartedLoopRef.current = false
   }, [lives])
 

--- a/packages/client/src/components/Game/bullet.tsx
+++ b/packages/client/src/components/Game/bullet.tsx
@@ -10,6 +10,11 @@ export const createBullet = (enemy: AbstractEntity): AbstractEntity => {
   const bulletSpeed = 5 // Задайте скорость пули
   const bulletDirection = { x: enemy.direction.x, y: enemy.direction.y }
 
+  if (bulletDirection.x === 0 && bulletDirection.y === 0) {
+    // Если направление врага не задано, выставляет направление врага вниз
+    bulletDirection.y = 1
+  }
+
   // Начальная позиция пули в зависимости от направления врага
   let bulletX, bulletY
 


### PR DESCRIPTION
### Какую задачу решаем
Выяснил причину зависших пуль. Причина в умершем противнике, который умер до начала движения и поэтому не имел направления. Решил придать им направление вниз карты sok-46

### Скриншоты/видяшка (если есть)

### TBD (если есть)